### PR TITLE
feat(recoil): dataState atom 생성 및 기존 MOCK_DATA를 default로 등록

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,56 +1,6 @@
 import Boards from './components/Boards';
 import Controller from './components/Controller';
 
-const MOCK_DATA = [
-  {
-    id: 1,
-    title: '작업 목록 1',
-    desc: '해야 할 작업 목록입니다. 우선순위를 정하고 진행하세요.',
-    type: 'todo',
-    created_at: '2023-10-01',
-  },
-  {
-    id: 2,
-    title: '작업 중 1',
-    desc: '현재 진행 중인 작업입니다. 작업 상태를 주기적으로 업데이트하세요.',
-    type: 'inprogress',
-    created_at: '2023-10-01',
-  },
-  {
-    id: 3,
-    title: '완료 1',
-    desc: '완료된 작업 목록입니다. 작업 결과를 검토하고 공유하세요.',
-    type: 'done',
-    created_at: '2023-10-01',
-  },
-  {
-    id: 4,
-    title: '작업 목록 2',
-    desc: '새로운 작업을 추가하고 계획을 세우세요. 중요한 작업부터 시작하세요.',
-    type: 'todo',
-    created_at: '2023-10-02',
-  },
-  {
-    id: 5,
-    title: '작업 중 2',
-    desc: '진행 중인 작업의 세부 사항을 확인하고 필요한 자원을 확보하세요.',
-    type: 'inprogress',
-    created_at: '2023-10-02',
-  },
-  {
-    id: 6,
-    title: '완료 2',
-    desc: '모든 작업이 성공적으로 완료되었습니다. 팀과 함께 성과를 축하하세요.',
-    type: 'done',
-    created_at: '2023-10-02',
-  },
-];
-
-// 기존 Boards 컴포넌트에서 Data를 MockData를 Props를 받고 이용하는 형태로 구성되어 있습니다.
-// 이를 Recoil을 이용하여 상태관리를 하도록 변경합니다.
-// Recoil을 사용하려면 RecoilRoot를 최상위 컴포넌트에 감싸야 합니다.
-// src/recoil/atoms.js 파일을 새로 생성하고, atom을 정의합니다.
-
 function App() {
   return (
     <div className="flex flex-col h-screen">
@@ -60,9 +10,9 @@ function App() {
       </header>
       <main className="flex-1 flex flex-col justify-between">
         <div className="grid grid-cols-3 gap-4 p-4 w-full">
-          <Boards type={'todo'} data={MOCK_DATA} />
-          <Boards type={'inprogress'} data={MOCK_DATA} />
-          <Boards type={'done'} data={MOCK_DATA} />
+          <Boards type={'todo'} />
+          <Boards type={'inprogress'} />
+          <Boards type={'done'} />
         </div>
         <Controller />
       </main>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client';
 import './main.css';
 import App from './App.jsx';
+import { RecoilRoot } from 'recoil';
 
-createRoot(document.getElementById('root')).render(<App />);
+createRoot(document.getElementById('root')).render(
+  <RecoilRoot>
+    <App />
+  </RecoilRoot>
+);

--- a/src/recoil/atom.js
+++ b/src/recoil/atom.js
@@ -1,0 +1,53 @@
+import { atom } from 'recoil';
+
+// Atom
+// - 상태(state)의 최소 단위, 전역적으로 사용 가능한 상태를 만들 때 사용된다.
+
+export const dataState = atom({
+  key: 'dataState', // Atom의 고유한 key
+  default: [
+    // 디폴드 값으로, 기존의 더미 데이터인 MOCK_DATA 변수 내용을 등록
+    {
+      id: 1,
+      title: '작업 목록 1',
+      desc: '해야 할 작업 목록입니다. 우선순위를 정하고 진행하세요.',
+      type: 'todo',
+      created_at: '2023-10-01',
+    },
+    {
+      id: 2,
+      title: '작업 중 1',
+      desc: '현재 진행 중인 작업입니다. 작업 상태를 주기적으로 업데이트하세요.',
+      type: 'inprogress',
+      created_at: '2023-10-01',
+    },
+    {
+      id: 3,
+      title: '완료 1',
+      desc: '완료된 작업 목록입니다. 작업 결과를 검토하고 공유하세요.',
+      type: 'done',
+      created_at: '2023-10-01',
+    },
+    {
+      id: 4,
+      title: '작업 목록 2',
+      desc: '새로운 작업을 추가하고 계획을 세우세요. 중요한 작업부터 시작하세요.',
+      type: 'todo',
+      created_at: '2023-10-02',
+    },
+    {
+      id: 5,
+      title: '작업 중 2',
+      desc: '진행 중인 작업의 세부 사항을 확인하고 필요한 자원을 확보하세요.',
+      type: 'inprogress',
+      created_at: '2023-10-02',
+    },
+    {
+      id: 6,
+      title: '완료 2',
+      desc: '모든 작업이 성공적으로 완료되었습니다. 팀과 함께 성과를 축하하세요.',
+      type: 'done',
+      created_at: '2023-10-02',
+    },
+  ],
+});


### PR DESCRIPTION
## Recoil로 전역 상태 관리하기

- Branch: refactor/recoil
- feat(recoil): dataState atom 생성 및 기존 MOCK_DATA를 default로 등록 

<br>

## 🧩 Problem & Requirements
1. App.jsx
- 기존의 더미 데이터인 MOCK_DATA 변수를 `src/recoil/atom.js`를 생성하여 전역 상태로 제작합니다.
- 해당 전역 상태는 default 값으로 MOCK_DATA 변수 내의 내용을 등록해야 합니다.
- `App.jsx`에서 `Boards.jsx`로 전달되던 `Data Props`를 제거합니다.

2. Tip
- 기존 Boards 컴포넌트에서 Data를 MockData를 Props를 받고 이용하는 형태로 구성되어 있습니다.
- 이를 Recoil을 이용하여 상태관리를 하도록 변경합니다.
- Recoil을 사용하려면 RecoilRoot를 최상위 컴포넌트에 감싸야 합니다.
- src/recoil/atoms.js 파일을 새로 생성하고, atom을 정의합니다.

<br>

## 📌 Notes
- `src/main.jsx`에서 `RecoilRoot`로 최상위 컴포넌트 감싸기
```jsx
createRoot(document.getElementById('root')).render(
  <RecoilRoot>
    <App />
  </RecoilRoot>
);
```
- `App.jsx`에서 `Boards.jsx`로 전달되던 `Data Props` 제거
```jsx
<Boards type={'todo'} />
<Boards type={'inprogress'} />
<Boards type={'done'} />
```
- dataState atom 생성 및 기존 MOCK_DATA를 default로 등록 
```jsx
export const dataState = atom({
  key: 'dataState', 
  default: [... ],
});
```

<br>


## 🎯 학습 목표 및 복습할 개념 체크 리스트

1. [x] 전역 상태 라이브러리인 Recoil를 사용하여 전역 상태를 관리할 수 있다.
2. [x] React에 대한 이해를 높이기 위해 칸반 보드 프로젝트를 직접 설계 및 구현하며 실습 중심의 학습을 진행합니다.
 
<br>

## 📚 Reference (선택)

- [Recoil](https://recoiljs.org/ko/docs/introduction/getting-started/)

---

> 💡 이 브랜치는 학습용이며, 개인 레포 내에서만 관리됩니다.
> 원본 레포에는 PR을 보내지 않고, 개인 히스토리용으로 정리한 브랜치입니다.