### PR TITLE
refactor(boards): data props 제거 및 Recoil 전역 상태 적용

### DIFF
--- a/src/components/Boards.jsx
+++ b/src/components/Boards.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import BoardDetailModal from './BoardDetailModal';
+import { useRecoilValue } from 'recoil';
+import { dataState } from '../recoil/atom';
 
 const typeToKorean = (type) => {
   switch (type) {
@@ -14,15 +16,9 @@ const typeToKorean = (type) => {
   }
 };
 
-//기존 Boards 컴포넌트에서 Data를 MockData를 Props를 받고 이용하는 형태로 구성되어 있습니다.
-//이를 Recoil을 이용하여 상태관리를 하도록 변경합니다.
-//data props 항목을 삭제합니다.
-//데이터를 type에 따라 필터링하여 각 칸반보드에서 사용해야 합니다. type은 prop로 전달되고 있습니다.
-//filteredData에 할당된 data를 필터링 하세요.
-//이후 Recoil의 useRecoilValue를 이용하여 Recoil의 상태를 가져오도록 수정합니다.
-
-const Boards = ({ type, data }) => {
-  const filteredData = data;
+const Boards = ({ type }) => {
+  const data = useRecoilValue(dataState);
+  const filteredData = data.filter((item) => item.type === type);
   const [item, setItem] = useState(null);
   const [isOpen, setIsOpen] = useState(false);
 


### PR DESCRIPTION
## Recoil로 전역 상태 관리하기

- Branch: refactor/recoil
- refactor(boards): data props 제거 및 Recoil 전역 상태 적용

<br>

## 🧩 Problem & Requirements
1. Boards.jsx
* 전달 받던 **Data Props**를 제거 해야 합니다.
* **useRecoilValue**를 사용하여 **data**변수를 선언하여 전역 상태를 가져와야 합니다.
* 데이터를 **type**에 따라 필터링하여 각 칸반 보드에 제공해야 합니다. type은 props로 전달됩니다.

2. Tip
- 기존 Boards 컴포넌트에서 Data를 MockData를 Props를 받고 이용하는 형태로 구성되어 있습니다.
- 이를 Recoil을 이용하여 상태관리를 하도록 변경합니다.
- data props 항목을 삭제합니다.
- 데이터를 type에 따라 필터링하여 각 칸반보드에서 사용해야 합니다. type은 prop로 전달되고 있습니다.
- filteredData에 할당된 data를 필터링 하세요.
- 이후 Recoil의 useRecoilValue를 이용하여 Recoil의 상태를 가져오도록 수정합니다.

<br>

## 📌 Notes
- data props 제거 및 Recoil 전역 상태 적용
```jsx
const Boards = ({ type }) => {
  const data = useRecoilValue(dataState);
  const filteredData = data.filter((item) => item.type === type);
);
```

<br>


## 🎯 학습 목표 및 복습할 개념 체크 리스트

1. [x] 전역 상태 라이브러리인 Recoil를 사용하여 전역 상태를 관리할 수 있다.
2. [x] React에 대한 이해를 높이기 위해 칸반 보드 프로젝트를 직접 설계 및 구현하며 실습 중심의 학습을 진행합니다.
 
<br>

## 📚 Reference (선택)

- [Recoil](https://recoiljs.org/ko/docs/introduction/getting-started/)

---

> 💡 이 브랜치는 학습용이며, 개인 레포 내에서만 관리됩니다.
> 원본 레포에는 PR을 보내지 않고, 개인 히스토리용으로 정리한 브랜치입니다.